### PR TITLE
Add export as NuGet package

### DIFF
--- a/.appveyor/Functions.ps1
+++ b/.appveyor/Functions.ps1
@@ -1,0 +1,9 @@
+Function RegexReplaceFile($file, $regex, $replace, $encoding = "ASCII") {
+    (Get-Content $file -encoding $encoding) -replace $regex,$replace | Set-Content $file -encoding $encoding
+}
+
+Function SetAppVeyorYmlVersion($version) {
+    $regex = "(version: ).+"
+    $replace = "`${1}$version"
+    RegexReplaceFile -file "appveyor.yml" -regex $regex -replace $replace
+}

--- a/.appveyor/PrepareNewBuildVersion.ps1
+++ b/.appveyor/PrepareNewBuildVersion.ps1
@@ -1,0 +1,26 @@
+. .\appveyor\Functions.ps1
+
+if (!$env:APPVEYOR_PULL_REQUEST_NUMBER) {
+    if ($env:APPVEYOR_REPO_TAG -eq "true") {
+        $match = Select-String -Path "appveyor.yml" -Pattern "version: (\d+)\.(\d+)\.(\d+)\.\{build\}"
+
+        $newVersion = $match.Matches[0].Groups[1].Value + "." + $match.Matches[0].Groups[2].Value + "." + ([convert]::ToInt32($match.Matches[0].Groups[3].Value, 10) + 1)
+        Write-Host "Prepare for next version automatically: $newVersion" -ForegroundColor "Yellow"
+
+        Write-Host "  - Apply to appveyor.yml" -ForegroundColor "Yellow"
+        SetAppVeyorYmlVersion "$newVersion.{build}"
+
+        Write-Host "  - Commit and push to GitHub repository" -ForegroundColor "Yellow"
+        git config --global credential.helper store
+        git config --global user.name $env:APPVEYOR_REPO_COMMIT_AUTHOR
+        git config --global user.email $env:APPVEYOR_REPO_COMMIT_AUTHOR_EMAIL
+        Add-Content "$env:USERPROFILE\.git-credentials" "https://$($env:GIT_ACCESS_TOKEN):x-oauth-basic@github.com`n"
+        git remote add github "https://github.com/$($env:APPVEYOR_REPO_NAME).git"
+        git checkout -q $env:APPVEYOR_REPO_BRANCH
+        git add "appveyor.yml"
+        git commit -q -m "[AppVeyor] Prepare for version $newVersion [ci skip]"
+        git push -q github master
+    } else {
+        Write-Host "No tag has been pushed; skip preparing for a new version" -ForegroundColor "Yellow"
+    }
+}

--- a/.appveyor/PrepareNewBuildVersion.ps1
+++ b/.appveyor/PrepareNewBuildVersion.ps1
@@ -1,4 +1,4 @@
-. .\appveyor\Functions.ps1
+. .\.appveyor\Functions.ps1
 
 if (!$env:APPVEYOR_PULL_REQUEST_NUMBER) {
     if ($env:APPVEYOR_REPO_TAG -eq "true") {

--- a/.appveyor/UpdateBuildVersion.ps1
+++ b/.appveyor/UpdateBuildVersion.ps1
@@ -1,0 +1,26 @@
+. .\appveyor\Functions.ps1
+
+$version = $env:APPVEYOR_BUILD_VERSION
+$csl_version = (Select-Xml -Path "CSL Common Shared\packages.config" -XPath "/packages/package[@id='CitiesSkylines.ICities']").node.version
+$version = "$version-$csl_version"
+if ($env:APPVEYOR_REPO_TAG -eq "false") {
+    $postfix = "dev"
+    if ($env:APPVEYOR_PULL_REQUEST_NUMBER) {
+        $postfix = "$postfix-PR$($env:APPVEYOR_PULL_REQUEST_NUMBER)"
+    } elseif ($env:APPVEYOR_REPO_BRANCH -ne "master") {
+        $postfix = "$postfix-$($env:APPVEYOR_REPO_BRANCH)"
+    }
+
+    if (!($version -like "*-$postfix")) {
+        $version = "$version-$postfix"
+    }
+}
+
+Write-Host "Current build version: $version" -ForegroundColor "Yellow"
+
+if ($version -ne $env:APPVEYOR_BUILD_VERSION) {
+    Write-Host "  - Send to AppVeyor Build Worker API" -ForegroundColor "Yellow"
+    Update-AppveyorBuild -Version $version
+} else {
+    Write-Host "  - AppVeyor build version is already up-to-date" -ForegroundColor "Yellow"
+}

--- a/.appveyor/UpdateBuildVersion.ps1
+++ b/.appveyor/UpdateBuildVersion.ps1
@@ -1,4 +1,4 @@
-. .\appveyor\Functions.ps1
+. .\.appveyor\Functions.ps1
 
 $version = $env:APPVEYOR_BUILD_VERSION
 $csl_version = (Select-Xml -Path "CSL Common Shared\packages.config" -XPath "/packages/package[@id='CitiesSkylines.ICities']").node.version

--- a/CSL Common Shared.UnitTests/Utils/FileUtilsTest.cs
+++ b/CSL Common Shared.UnitTests/Utils/FileUtilsTest.cs
@@ -32,7 +32,7 @@ namespace CommonShared.UnitTests.Utils
         [TearDown]
         public virtual void Dispose()
         {
-            PluginUtils.Cleanup();
+            PluginUtils.CleanUp();
         }
 
         [Test]

--- a/CSL Common Shared.UnitTests/Utils/PluginUtilsTest.cs
+++ b/CSL Common Shared.UnitTests/Utils/PluginUtilsTest.cs
@@ -28,7 +28,7 @@ namespace CommonShared.UnitTests.Utils
         [TearDown]
         public virtual void Dispose()
         {
-            PluginUtils.Cleanup();
+            PluginUtils.CleanUp();
         }
 
         [Test]

--- a/CSL Common Shared/CSL Common Shared.csproj
+++ b/CSL Common Shared/CSL Common Shared.csproj
@@ -21,6 +21,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <DocumentationFile>bin\Debug\CommonShared.XML</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -30,6 +31,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <DocumentationFile>bin\Release\CommonShared.XML</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Assembly-CSharp">

--- a/CSL Common Shared/CSL Common Shared.nuspec
+++ b/CSL Common Shared/CSL Common Shared.nuspec
@@ -10,7 +10,4 @@
     <projectUrl>https://github.com/Archomeda/csl-common-shared-library</projectUrl>
     <description>Custom library for my Cities Skylines mods.</description>
   </metadata>
-  <files>
-    <file src="bin\Release\CommonShared.XML" target="lib\net35" />
-  </files>
 </package>

--- a/CSL Common Shared/CSL Common Shared.nuspec
+++ b/CSL Common Shared/CSL Common Shared.nuspec
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<package>
+  <metadata>
+    <id>CslCommonShared</id>
+    <version>$version$</version>
+    <title>Cities Skylines: Common Shared Library</title>
+    <authors>Archomeda</authors>
+    <owners>Archomeda</owners>
+    <licenseUrl>https://github.com/Archomeda/csl-common-shared-library/blob/master/LICENSE</licenseUrl>
+    <projectUrl>https://github.com/Archomeda/csl-common-shared-library</projectUrl>
+    <description>Custom library for my Cities Skylines mods.</description>
+  </metadata>
+  <files>
+    <file src="bin\Release\CommonShared.XML" target="lib\net35" />
+  </files>
+</package>

--- a/CSL Common Shared/Configuration/Config.cs
+++ b/CSL Common Shared/Configuration/Config.cs
@@ -18,6 +18,7 @@ namespace CommonShared.Configuration
         /// </summary>
         /// <typeparam name="T">The config object type.</typeparam>
         /// <param name="filename">The name of the configuration file.</param>
+        /// <returns>The configuration instance.</returns>
         public static T LoadConfig<T>(string filename) where T : new()
         {
             if (File.Exists(filename))

--- a/CSL Common Shared/Configuration/ConfigMigratorBase.cs
+++ b/CSL Common Shared/Configuration/ConfigMigratorBase.cs
@@ -8,7 +8,7 @@ using System.Xml.Serialization;
 namespace CommonShared.Configuration
 {
     /// <summary>
-    /// An abstract class that implements basic functionality of <see cref="IConfigMigrator"/>.
+    /// An abstract class that implements basic functionality of <see cref="T:IConfigMigrator`1"/>.
     /// </summary>
     /// <typeparam name="T">The configuration object type.</typeparam>
     public abstract class ConfigMigratorBase<T> : IConfigMigrator<T> where T : VersionedConfig, new()

--- a/CSL Common Shared/Configuration/IConfigMigrator.cs
+++ b/CSL Common Shared/Configuration/IConfigMigrator.cs
@@ -8,7 +8,7 @@ namespace CommonShared.Configuration
 {
     /// <summary>
     /// An interface for implementing configuration migrators.
-    /// Typically you would want to use <see cref="ConfigMigratorBase"/>.
+    /// Typically you would want to use <see cref="T:ConfigMigratorBase`1" />.
     /// </summary>
     /// <typeparam name="T">The configuration object type.</typeparam>
     public interface IConfigMigrator<T> where T : VersionedConfig

--- a/CSL Common Shared/Configuration/VersionedConfig.cs
+++ b/CSL Common Shared/Configuration/VersionedConfig.cs
@@ -16,6 +16,9 @@ namespace CommonShared.Configuration
         /// <summary>
         /// Gets or sets the version of this configuration file.
         /// </summary>
+        /// <value>
+        /// The version.
+        /// </value>
         [XmlAttribute("version")]
         public virtual uint Version { get; set; }
 
@@ -25,6 +28,7 @@ namespace CommonShared.Configuration
         /// <typeparam name="T">The config object type.</typeparam>
         /// <param name="filename">The name of the configuration file.</param>
         /// <param name="migrator">The config migrator object.</param>
+        /// <returns>The configuration instance.</returns>
         public static T LoadConfig<T>(string filename, IConfigMigrator<T> migrator) where T : VersionedConfig, new()
         {
             if (File.Exists(filename))

--- a/CSL Common Shared/Defs/GameObjectDefs.cs
+++ b/CSL Common Shared/Defs/GameObjectDefs.cs
@@ -5,9 +5,19 @@ using System.Text;
 
 namespace CommonShared.Defs
 {
+    /// <summary>
+    /// A static class that contains definitions of various used GameObjects.
+    /// </summary>
     public static class GameObjectDefs
     {
+        /// <summary>
+        /// The GameObject ID of the tabstrip of the keymapping options section.
+        /// </summary>
         public const string ID_KEYMAPPING_TABSTRIP = "KeyMappingTabStrip";
+
+        /// <summary>
+        /// The GameObject ID of the toolstrip container in-game.
+        /// </summary>
         public const string ID_TSCONTAINER = "TSContainer";
     }
 }

--- a/CSL Common Shared/Defs/UITemplateDefs.cs
+++ b/CSL Common Shared/Defs/UITemplateDefs.cs
@@ -5,8 +5,14 @@ using System.Text;
 
 namespace CommonShared.Defs
 {
+    /// <summary>
+    /// A static class that contains definitions of various used UI templates.
+    /// </summary>
     public static class UITemplateDefs
     {
+        /// <summary>
+        /// The UI template ID of the options scroll panel.
+        /// </summary>
         public const string ID_OPTIONS_SCROLL_PANEL_TEMPLATE = "OptionsScrollPanelTemplate";
     }
 }

--- a/CSL Common Shared/Extensions/DictionaryExtensions.cs
+++ b/CSL Common Shared/Extensions/DictionaryExtensions.cs
@@ -6,7 +6,7 @@ using System.Text;
 namespace CommonShared.Extensions
 {
     /// <summary>
-    /// This static class contains extensions to <see cref="IDictionary"/> classes.
+    /// This static class contains extensions to <see cref="T:IDictionary`2"/> classes.
     /// </summary>
     public static class DictionaryExtensions
     {
@@ -19,7 +19,7 @@ namespace CommonShared.Extensions
         /// <param name="key">The key of the value to get.</param>
         /// <param name="defaultValue">The default value to use when the key has not been found in the dictionary.</param>
         /// <param name="value">When this method returns, contains the value associated with the specified key, if the is found; otherwise, the specified default value. This parameter is passed uninitialized.</param>
-        /// <returns>True if the dictionary contains an element with the specified key; otherwise, false.</returns>
+        /// <returns><c>true</c> if the dictionary contains an element with the specified key; otherwise, <c>false</c>.</returns>
         public static bool TryGetValueOrDefault<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key, TValue defaultValue, out TValue value)
         {
             if (!dictionary.TryGetValue(key, out value))

--- a/CSL Common Shared/Proxies/Events/ToolbarEvents.cs
+++ b/CSL Common Shared/Proxies/Events/ToolbarEvents.cs
@@ -18,6 +18,9 @@ namespace CommonShared.Proxies.Events
 
         private static bool isToolbarOpen = false;
 
+        /// <summary>
+        /// The handler that is used when the toolbar is opened.
+        /// </summary>
         public delegate void ToolbarOpenedEventHandler();
 
         private static event ToolbarOpenedEventHandler toolbarOpened;
@@ -53,6 +56,9 @@ namespace CommonShared.Proxies.Events
         }
 
 
+        /// <summary>
+        /// The handler that is used when the toolbar is closed.
+        /// </summary>
         public delegate void ToolbarClosedEventHandler();
 
         private static event ToolbarClosedEventHandler toolbarClosed;

--- a/CSL Common Shared/Proxies/IO/DataLocationProxy.cs
+++ b/CSL Common Shared/Proxies/IO/DataLocationProxy.cs
@@ -7,83 +7,134 @@ using ColossalFramework.IO;
 
 namespace CommonShared.Proxies.IO
 {
+    /// <summary>
+    /// The default proxy to interface with the <see cref="DataLocation" /> of Cities Skylines.
+    /// </summary>
     public class DataLocationProxy : SingletonLite<DataLocationProxy>, IDataLocationInteractor
     {
+        /// <summary>
+        /// The company name.
+        /// </summary>
         public string CompanyName
         {
             get { return DataLocation.companyName; }
         }
 
+        /// <summary>
+        /// The product version.
+        /// </summary>
         public uint ProductVersion
         {
             get { return DataLocation.productVersion; }
         }
 
+        /// <summary>
+        /// The product version string.
+        /// </summary>
         public string ProductVersionString
         {
             get { return DataLocation.productVersionString; }
         }
 
+        /// <summary>
+        /// The product name.
+        /// </summary>
         public string ProductName
         {
             get { return DataLocation.productName; }
         }
 
+        /// <summary>
+        /// The application base.
+        /// </summary>
         public string ApplicationBase
         {
             get { return DataLocation.applicationBase; }
         }
 
+        /// <summary>
+        /// The game content path.
+        /// </summary>
         public string GameContentPath
         {
             get { return DataLocation.gameContentPath; }
         }
 
+        /// <summary>
+        /// The add-ons path.
+        /// </summary>
         public string AddonsPath
         {
             get { return DataLocation.addonsPath; }
         }
 
+        /// <summary>
+        /// The mods path.
+        /// </summary>
         public string ModsPath
         {
             get { return DataLocation.modsPath; }
         }
 
+        /// <summary>
+        /// The assets path.
+        /// </summary>
         public string AssetsPath
         {
             get { return DataLocation.assetsPath; }
         }
 
+        /// <summary>
+        /// The current directory.
+        /// </summary>
         public string CurrentDirectory
         {
             get { return DataLocation.currentDirectory; }
         }
 
+        /// <summary>
+        /// The assembly directory.
+        /// </summary>
         public string AssemblyDirectory
         {
             get { return DataLocation.assemblyDirectory; }
         }
 
+        /// <summary>
+        /// The executable directory.
+        /// </summary>
         public string ExecutableDirectory
         {
             get { return DataLocation.executableDirectory; }
         }
 
+        /// <summary>
+        /// The temp folder.
+        /// </summary>
         public string TempFolder
         {
             get { return DataLocation.tempFolder; }
         }
 
+        /// <summary>
+        /// The local application data directory.
+        /// </summary>
         public string LocalApplicationData
         {
             get { return DataLocation.localApplicationData; }
         }
 
+        /// <summary>
+        /// The save location.
+        /// </summary>
         public string SaveLocation
         {
             get { return DataLocation.saveLocation; }
         }
 
+        /// <summary>
+        /// The map location.
+        /// </summary>
         public string MapLocation
         {
             get { return DataLocation.mapLocation; }

--- a/CSL Common Shared/Proxies/IO/IDataLocationInteractor.cs
+++ b/CSL Common Shared/Proxies/IO/IDataLocationInteractor.cs
@@ -5,23 +5,90 @@ using System.Text;
 
 namespace CommonShared.Proxies.IO
 {
+    /// <summary>
+    /// The DataLocation interactor interface. Must be used when creating a custom proxy.
+    /// See <see cref="DataLocationProxy" /> for the default interaction with Cities Skylines.
+    /// </summary>
     public interface IDataLocationInteractor
     {
+        /// <summary>
+        /// The company name.
+        /// </summary>
         string CompanyName { get; }
+
+        /// <summary>
+        /// The product version.
+        /// </summary>
         uint ProductVersion { get; }
+
+        /// <summary>
+        /// The product version string.
+        /// </summary>
         string ProductVersionString { get; }
+
+        /// <summary>
+        /// The product name.
+        /// </summary>
         string ProductName { get; }
+
+        /// <summary>
+        /// The application base.
+        /// </summary>
         string ApplicationBase { get; }
+
+        /// <summary>
+        /// The game content path.
+        /// </summary>
         string GameContentPath { get; }
+
+        /// <summary>
+        /// The add-ons path.
+        /// </summary>
         string AddonsPath { get; }
+
+        /// <summary>
+        /// The mods path.
+        /// </summary>
         string ModsPath { get; }
+
+        /// <summary>
+        /// The assets path.
+        /// </summary>
         string AssetsPath { get; }
+
+        /// <summary>
+        /// The current directory.
+        /// </summary>
         string CurrentDirectory { get; }
+
+        /// <summary>
+        /// The assembly directory.
+        /// </summary>
         string AssemblyDirectory { get; }
+
+        /// <summary>
+        /// The executable directory.
+        /// </summary>
         string ExecutableDirectory { get; }
+
+        /// <summary>
+        /// The temp folder.
+        /// </summary>
         string TempFolder { get; }
+
+        /// <summary>
+        /// The local application data directory.
+        /// </summary>
         string LocalApplicationData { get; }
+
+        /// <summary>
+        /// The save location.
+        /// </summary>
         string SaveLocation { get; }
+
+        /// <summary>
+        /// The map location.
+        /// </summary>
         string MapLocation { get; }
     }
 }

--- a/CSL Common Shared/Proxies/Plugins/IPluginInfoInteractor.cs
+++ b/CSL Common Shared/Proxies/Plugins/IPluginInfoInteractor.cs
@@ -7,21 +7,108 @@ using ColossalFramework.Steamworks;
 
 namespace CommonShared.Proxies.Plugins
 {
+    /// <summary>
+    /// The PluginInfo interactor interface. Must be used when creating a custom proxy.
+    /// See <see cref="PluginInfoProxy" /> for the default interaction with Cities Skylines.
+    /// </summary>
     public interface IPluginInfoInteractor
     {
+        /// <summary>
+        /// Gets the assemblies.
+        /// </summary>
+        /// <value>
+        /// The list of assemblies.
+        /// </value>
         IList<Assembly> Assemblies { get; }
+
+        /// <summary>
+        /// Gets the assemblies string.
+        /// </summary>
+        /// <value>
+        /// The assemblies string.
+        /// </value>
         string AssembliesString { get; }
+
+        /// <summary>
+        /// Gets the number of assemblies.
+        /// </summary>
+        /// <value>
+        /// The number of assemblies.
+        /// </value>
         int AssemblyCount { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether this plugin is built in.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if this plugin is built in; otherwise, <c>false</c>.
+        /// </value>
         bool IsBuiltIn { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether this plugin is enabled.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if this plugin is enabled; otherwise, <c>false</c>.
+        /// </value>
         bool IsEnabled { get; }
+
+        /// <summary>
+        /// Gets the mod path.
+        /// </summary>
+        /// <value>
+        /// The mod path.
+        /// </value>
         string ModPath { get; }
+
+        /// <summary>
+        /// Gets the name.
+        /// </summary>
+        /// <value>
+        /// The name.
+        /// </value>
         string Name { get; }
+
+        /// <summary>
+        /// Gets the published file Steam id.
+        /// </summary>
+        /// <value>
+        /// The published file Steam id.
+        /// </value>
         PublishedFileId PublishedFileID { get; }
+
+        /// <summary>
+        /// Gets the mod instance.
+        /// </summary>
+        /// <value>
+        /// The mod instance.
+        /// </value>
         object UserModInstance { get; }
 
+        /// <summary>
+        /// Adds an assembly.
+        /// </summary>
+        /// <param name="asm">The assembly.</param>
         void AddAssembly(Assembly asm);
+
+        /// <summary>
+        /// Gets the instances.
+        /// </summary>
+        /// <typeparam name="T">The type of the instances.</typeparam>
+        /// <returns>The instances.</returns>
         T[] GetInstances<T>() where T : class;
+
+        /// <summary>
+        /// Returns a <see cref="System.String" /> that represents this plugin.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="System.String" /> that represents this plugin.
+        /// </returns>
         string ToString();
+
+        /// <summary>
+        /// Unloads this plugin.
+        /// </summary>
         void Unload();
     }
 }

--- a/CSL Common Shared/Proxies/Plugins/IPluginManagerInteractor.cs
+++ b/CSL Common Shared/Proxies/Plugins/IPluginManagerInteractor.cs
@@ -6,16 +6,54 @@ using ColossalFramework.Plugins;
 
 namespace CommonShared.Proxies.Plugins
 {
+    /// <summary>
+    /// The PluginManager interactor interface. Must be used when creating a custom proxy.
+    /// See <see cref="PluginManagerProxy" /> for the default interaction with Cities Skylines.
+    /// </summary>
     public interface IPluginManagerInteractor
     {
+        /// <summary>
+        /// Gets the number of enabled mods.
+        /// </summary>
+        /// <value>
+        /// The number of enabled mods.
+        /// </value>
         int EnabledModCount { get; }
+
+        /// <summary>
+        /// Gets the number of mods.
+        /// </summary>
+        /// <value>
+        /// The number of mods.
+        /// </value>
         int ModCount { get; }
 
+        /// <summary>
+        /// Occurs when plugins have changed.
+        /// </summary>
         event PluginManager.PluginsChangedHandler OnPluginsChanged;
+
+        /// <summary>
+        /// Occurs when a plugin state has changed.
+        /// </summary>
         event PluginManager.PluginsChangedHandler OnPluginsStateChanged;
 
+        /// <summary>
+        /// Gets the implementations.
+        /// </summary>
+        /// <typeparam name="T">The type of the implementations.</typeparam>
+        /// <returns>The list of implementations.</returns>
         List<T> GetImplementations<T>() where T : class;
+
+        /// <summary>
+        /// Gets the plugins information.
+        /// </summary>
+        /// <returns>The plugins information.</returns>
         IEnumerable<IPluginInfoInteractor> GetPluginsInfo();
+
+        /// <summary>
+        /// Loads the plugins.
+        /// </summary>
         void LoadPlugins();
     }
 }

--- a/CSL Common Shared/Proxies/Plugins/PluginInfoProxy.cs
+++ b/CSL Common Shared/Proxies/Plugins/PluginInfoProxy.cs
@@ -9,17 +9,35 @@ using CommonShared.Utils;
 
 namespace CommonShared.Proxies.Plugins
 {
+    /// <summary>
+    /// The default proxy to interface with the <see cref="PluginManager.PluginInfo" /> of Cities Skylines.
+    /// </summary>
     public class PluginInfoProxy : IPluginInfoInteractor
     {
+        /// <summary>
+        /// Gets the original plugin information.
+        /// </summary>
+        /// <value>
+        /// The original plugin information.
+        /// </value>
         public PluginManager.PluginInfo OriginalPluginInfo { get; private set; }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PluginInfoProxy"/> class.
+        /// </summary>
+        /// <param name="originalPluginInfo">The original plugin information.</param>
         public PluginInfoProxy(PluginManager.PluginInfo originalPluginInfo)
         {
             this.OriginalPluginInfo = originalPluginInfo;
         }
 
-
         private IList<Assembly> assemblies;
+        /// <summary>
+        /// Gets the assemblies.
+        /// </summary>
+        /// <value>
+        /// The list of assemblies.
+        /// </value>
         public IList<Assembly> Assemblies
         {
             get
@@ -30,62 +48,129 @@ namespace CommonShared.Proxies.Plugins
             }
         }
 
+        /// <summary>
+        /// Gets the assemblies string.
+        /// </summary>
+        /// <value>
+        /// The assemblies string.
+        /// </value>
         public string AssembliesString
         {
             get { return this.OriginalPluginInfo.assembliesString; }
         }
 
+        /// <summary>
+        /// Gets the number of assemblies.
+        /// </summary>
+        /// <value>
+        /// The number of assemblies.
+        /// </value>
         public int AssemblyCount
         {
             get { return this.OriginalPluginInfo.assemblyCount; }
         }
 
+        /// <summary>
+        /// Gets a value indicating whether this plugin is built in.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if this plugin is built in; otherwise, <c>false</c>.
+        /// </value>
         public bool IsBuiltIn
         {
             get { return this.OriginalPluginInfo.isBuiltin; }
         }
 
+        /// <summary>
+        /// Gets a value indicating whether this plugin is enabled.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if this plugin is enabled; otherwise, <c>false</c>.
+        /// </value>
         public bool IsEnabled
         {
             get { return this.OriginalPluginInfo.isEnabled; }
         }
 
+        /// <summary>
+        /// Gets the mod path.
+        /// </summary>
+        /// <value>
+        /// The mod path.
+        /// </value>
         public string ModPath
         {
             get { return this.OriginalPluginInfo.modPath; }
         }
 
+        /// <summary>
+        /// Gets the name.
+        /// </summary>
+        /// <value>
+        /// The name.
+        /// </value>
         public string Name
         {
             get { return this.OriginalPluginInfo.name; }
         }
 
+        /// <summary>
+        /// Gets the published file Steam id.
+        /// </summary>
+        /// <value>
+        /// The published file Steam id.
+        /// </value>
         public PublishedFileId PublishedFileID
         {
             get { return this.OriginalPluginInfo.publishedFileID; }
         }
 
+        /// <summary>
+        /// Gets the mod instance.
+        /// </summary>
+        /// <value>
+        /// The mod instance.
+        /// </value>
         public object UserModInstance
         {
             get { return this.OriginalPluginInfo.userModInstance; }
         }
 
-
+        /// <summary>
+        /// Adds an assembly.
+        /// </summary>
+        /// <param name="asm">The assembly.</param>
         public void AddAssembly(Assembly asm)
         {
             this.OriginalPluginInfo.AddAssembly(asm);
         }
 
+        /// <summary>
+        /// Gets the instances.
+        /// </summary>
+        /// <typeparam name="T">The type of the instances.</typeparam>
+        /// <returns>
+        /// The instances.
+        /// </returns>
         public T[] GetInstances<T>() where T : class
         {
             return this.OriginalPluginInfo.GetInstances<T>();
         }
 
+        /// <summary>
+        /// Returns a <see cref="System.String" /> that represents this plugin.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="System.String" /> that represents this plugin.
+        /// </returns>
         public override string ToString()
         {
             return this.OriginalPluginInfo.ToString();
         }
 
+        /// <summary>
+        /// Unloads this plugin.
+        /// </summary>
         public void Unload()
         {
             this.OriginalPluginInfo.Unload();

--- a/CSL Common Shared/Proxies/Plugins/PluginManagerProxy.cs
+++ b/CSL Common Shared/Proxies/Plugins/PluginManagerProxy.cs
@@ -7,19 +7,36 @@ using ColossalFramework.Plugins;
 
 namespace CommonShared.Proxies.Plugins
 {
+    /// <summary>
+    /// The default proxy to interface with the <see cref="PluginManager" /> of Cities Skylines.
+    /// </summary>
     public class PluginManagerProxy : SingletonLite<PluginManagerProxy>, IPluginManagerInteractor
     {
+        /// <summary>
+        /// Gets the number of enabled mods.
+        /// </summary>
+        /// <value>
+        /// The number of enabled mods.
+        /// </value>
         public int EnabledModCount
         {
             get { return PluginManager.instance.enabledModCount; }
         }
 
+        /// <summary>
+        /// Gets the number of mods.
+        /// </summary>
+        /// <value>
+        /// The number of mods.
+        /// </value>
         public int ModCount
         {
             get { return PluginManager.instance.modCount; }
         }
 
-
+        /// <summary>
+        /// Occurs when plugins have changed.
+        /// </summary>
         public event PluginManager.PluginsChangedHandler OnPluginsChanged
         {
             add
@@ -32,6 +49,9 @@ namespace CommonShared.Proxies.Plugins
             }
         }
 
+        /// <summary>
+        /// Occurs when a plugin state has changed.
+        /// </summary>
         public event PluginManager.PluginsChangedHandler OnPluginsStateChanged
         {
             add
@@ -44,17 +64,32 @@ namespace CommonShared.Proxies.Plugins
             }
         }
 
-
+        /// <summary>
+        /// Gets the implementations.
+        /// </summary>
+        /// <typeparam name="T">The type of the implementations.</typeparam>
+        /// <returns>
+        /// The list of implementations.
+        /// </returns>
         public List<T> GetImplementations<T>() where T : class
         {
             return PluginManager.instance.GetImplementations<T>();
         }
 
+        /// <summary>
+        /// Gets the plugins information.
+        /// </summary>
+        /// <returns>
+        /// The plugins information.
+        /// </returns>
         public IEnumerable<IPluginInfoInteractor> GetPluginsInfo()
         {
             return PluginManager.instance.GetPluginsInfo().Select(i => (IPluginInfoInteractor)new PluginInfoProxy(i));
         }
 
+        /// <summary>
+        /// Loads the plugins.
+        /// </summary>
         public void LoadPlugins()
         {
             PluginManager.instance.LoadPlugins();

--- a/CSL Common Shared/SerializableDictionary.cs
+++ b/CSL Common Shared/SerializableDictionary.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Xml;
 using System.Xml.Serialization;
 
 namespace CommonShared
@@ -16,12 +17,20 @@ namespace CommonShared
     public class SerializableDictionary<TKey, TValue> : Dictionary<TKey, TValue>, IXmlSerializable
     {
         #region IXmlSerializable Members
+        /// <summary>
+        /// Not used.
+        /// </summary>
+        /// <returns>Returns <c>null</c>.</returns>
         public System.Xml.Schema.XmlSchema GetSchema()
         {
             return null;
         }
 
-        public void ReadXml(System.Xml.XmlReader reader)
+        /// <summary>
+        /// Generates an object from its XML representation.
+        /// </summary>
+        /// <param name="reader">The <see cref="T:System.Xml.XmlReader" /> stream from which the object is deserialized.</param>
+        public void ReadXml(XmlReader reader)
         {
             XmlSerializer keySerializer = new XmlSerializer(typeof(TKey));
             XmlSerializer valueSerializer = new XmlSerializer(typeof(TValue));
@@ -52,7 +61,11 @@ namespace CommonShared
             reader.ReadEndElement();
         }
 
-        public void WriteXml(System.Xml.XmlWriter writer)
+        /// <summary>
+        /// Converts an object into its XML representation.
+        /// </summary>
+        /// <param name="writer">The <see cref="T:System.Xml.XmlWriter" /> stream to which the object is serialized.</param>
+        public void WriteXml(XmlWriter writer)
         {
             XmlSerializer keySerializer = new XmlSerializer(typeof(TKey));
             XmlSerializer valueSerializer = new XmlSerializer(typeof(TValue));

--- a/CSL Common Shared/UI/Extensions/UIHelperBaseExtensions.cs
+++ b/CSL Common Shared/UI/Extensions/UIHelperBaseExtensions.cs
@@ -9,7 +9,7 @@ using UnityEngine;
 namespace CommonShared.UI.Extensions
 {
     /// <summary>
-    /// A class that contains extensions for <see cref="UIHelperBase"/> objects.
+    /// A class that contains extensions for <see cref="ICities.UIHelperBase"/> objects.
     /// </summary>
     public static class UIHelperBaseExtensions
     {

--- a/CSL Common Shared/UI/Window.cs
+++ b/CSL Common Shared/UI/Window.cs
@@ -12,8 +12,14 @@ namespace CommonShared.UI
     /// </summary>
     public class Window : UIPanel
     {
-        public const float TitleBarHeight = 40;
+        /// <summary>
+        /// The title bar height.
+        /// </summary>
+        protected const float TitleBarHeight = 40;
 
+        /// <summary>
+        /// Starts this window.
+        /// </summary>
         public override void Start()
         {
             base.Start();
@@ -35,6 +41,9 @@ namespace CommonShared.UI
             this.CreateContentPanel();
         }
 
+        /// <summary>
+        /// Closes this window.
+        /// </summary>
         public virtual void Close()
         {
             this.Hide();
@@ -45,6 +54,12 @@ namespace CommonShared.UI
         }
 
         private string title = "";
+        /// <summary>
+        /// Gets or sets the window title.
+        /// </summary>
+        /// <value>
+        /// The window title.
+        /// </value>
         public string Title
         {
             get
@@ -61,6 +76,12 @@ namespace CommonShared.UI
             }
         }
 
+        /// <summary>
+        /// Gets the content panel.
+        /// </summary>
+        /// <value>
+        /// The content panel.
+        /// </value>
         public UIPanel ContentPanel
         {
             get
@@ -69,11 +90,38 @@ namespace CommonShared.UI
             }
         }
 
+        /// <summary>
+        /// Gets the title object.
+        /// </summary>
+        /// <value>
+        /// The title object.
+        /// </value>
         protected GameObject TitleObject { get; private set; }
+        /// <summary>
+        /// Gets the drag handle object.
+        /// </summary>
+        /// <value>
+        /// The drag handle object.
+        /// </value>
         protected GameObject DragHandleObject { get; private set; }
+        /// <summary>
+        /// Gets the close button object.
+        /// </summary>
+        /// <value>
+        /// The close button object.
+        /// </value>
         protected GameObject CloseButtonObject { get; private set; }
+        /// <summary>
+        /// Gets the content panel object.
+        /// </summary>
+        /// <value>
+        /// The content panel object.
+        /// </value>
         protected GameObject ContentPanelObject { get; private set; }
 
+        /// <summary>
+        /// Creates the title.
+        /// </summary>
         protected virtual void CreateTitle()
         {
             this.TitleObject = new GameObject("Title");
@@ -88,6 +136,9 @@ namespace CommonShared.UI
             title.atlas = this.atlas;
         }
 
+        /// <summary>
+        /// Creates the drag handle.
+        /// </summary>
         protected virtual void CreateDragHandle()
         {
             this.DragHandleObject = new GameObject("DragHandler");
@@ -99,6 +150,9 @@ namespace CommonShared.UI
             dragHandle.size = new Vector2(this.width, TitleBarHeight);
         }
 
+        /// <summary>
+        /// Creates the close button.
+        /// </summary>
         protected virtual void CreateCloseButton()
         {
             this.CloseButtonObject = new GameObject("CloseButton");
@@ -117,6 +171,9 @@ namespace CommonShared.UI
             closeButton.atlas = this.atlas;
         }
 
+        /// <summary>
+        /// Creates the content panel.
+        /// </summary>
         protected virtual void CreateContentPanel()
         {
             this.ContentPanelObject = new GameObject("ContentPanel");
@@ -130,6 +187,10 @@ namespace CommonShared.UI
             contentPanel.atlas = this.atlas;
         }
 
+        /// <summary>
+        /// Called when a key is pressed.
+        /// </summary>
+        /// <param name="p">The event parameter.</param>
         protected override void OnKeyDown(UIKeyEventParameter p)
         {
             if (!p.used && p.keycode == KeyCode.Escape)
@@ -140,6 +201,10 @@ namespace CommonShared.UI
             base.OnKeyDown(p);
         }
 
+        /// <summary>
+        /// Shows the window.
+        /// </summary>
+        /// <param name="window">The window.</param>
         public static void ShowWindow(Window window)
         {
             window.CenterToParent();

--- a/CSL Common Shared/Utils/DetourUtils.cs
+++ b/CSL Common Shared/Utils/DetourUtils.cs
@@ -37,9 +37,19 @@ using System.Runtime.InteropServices;
 
 namespace CommonShared.Utils
 {
+    /// <summary>
+    /// A struct that represents a detour calls state.
+    /// </summary>
     public struct DetourCallsState
     {
+        /// <summary>
+        /// A byte representing the state.
+        /// </summary>
         public byte a, b, c, d, e;
+
+        /// <summary>
+        /// A unsigned long represeting the state.
+        /// </summary>
         public ulong f;
     }
 
@@ -52,8 +62,8 @@ namespace CommonShared.Utils
         /// <summary>
         /// Redirects all calls from method 'from' to method 'to'.
         /// </summary>
-        /// <param name="from"></param>
-        /// <param name="to"></param>
+        /// <param name="from">The method to redirect.</param>
+        /// <param name="to">The method to redirect to.</param>
         public static DetourCallsState RedirectCalls(MethodInfo from, MethodInfo to)
         {
             // GetFunctionPointer enforces compilation of the method.
@@ -62,6 +72,11 @@ namespace CommonShared.Utils
             return PatchJumpTo(fptr1, fptr2);
         }
 
+        /// <summary>
+        /// Reverts a redirect.
+        /// </summary>
+        /// <param name="from">The method to revert the redirect.</param>
+        /// <param name="state">The state.</param>
         public static void RevertRedirect(MethodInfo from, DetourCallsState state)
         {
             var fptr1 = from.MethodHandle.GetFunctionPointer();

--- a/CSL Common Shared/Utils/PluginUtils.cs
+++ b/CSL Common Shared/Utils/PluginUtils.cs
@@ -141,7 +141,10 @@ namespace CommonShared.Utils
             }
         }
 
-        public static void Cleanup()
+        /// <summary>
+        /// Cleans up this instance.
+        /// </summary>
+        public static void CleanUp()
         {
             pluginEnabledList.Clear();
             pluginStateChangeCallbacks.Clear();

--- a/CSL Common Shared/Utils/ReflectionUtils.cs
+++ b/CSL Common Shared/Utils/ReflectionUtils.cs
@@ -64,7 +64,7 @@ namespace CommonShared.Utils
         /// <summary>
         /// Invokes a private static method.
         /// </summary>
-        /// <param name="type">The object to invoke the method on.</param>
+        /// <param name="type">The object type to invoke the method on.</param>
         /// <param name="name">The name of the method.</param>
         /// <param name="args">The arguments to pass to the method.</param>
         public static void InvokePrivateStaticMethod(Type type, string name, params object[] args)
@@ -77,7 +77,7 @@ namespace CommonShared.Utils
         /// Invokes a private static method with a return value.
         /// </summary>
         /// <typeparam name="T">The object type of the returned value.</typeparam>
-        /// <param name="obj">The object to invoke the method on.</param>
+        /// <param name="type">The object type to invoke the method on.</param>
         /// <param name="name">The name of the method.</param>
         /// <param name="args">The arguments to pass to the method.</param>
         /// <returns>The return value of the invoked method.</returns>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,4 @@
-# We follow the versioning of Cities Skylines
-version: 1.1.1.{build}
+version: 1.2.0.{build}
 
 configuration: Release
 
@@ -10,8 +9,12 @@ cache:
   - packages -> **\packages.config
 
 before_build:
+  - ps: appveyor\UpdateBuildVersion.ps1
   - nuget restore
 
 build:
   verbosity: minimal
   publish_nuget: true
+
+on_success:
+  - ps: appveyor\PrepareNewBuildVersion.ps1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,6 +3,9 @@ version: 1.1.1.{build}
 
 configuration: Release
 
+assembly_info:
+  patch: true
+
 cache:
   - packages -> **\packages.config
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,3 +11,4 @@ before_build:
 
 build:
   verbosity: minimal
+  publish_nuget: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,7 @@ cache:
   - packages -> **\packages.config
 
 before_build:
-  - ps: appveyor\UpdateBuildVersion.ps1
+  - ps: .appveyor\UpdateBuildVersion.ps1
   - nuget restore
 
 build:
@@ -17,4 +17,4 @@ build:
   publish_nuget: true
 
 on_success:
-  - ps: appveyor\PrepareNewBuildVersion.ps1
+  - ps: .appveyor\PrepareNewBuildVersion.ps1


### PR DESCRIPTION
This will provide the library as a NuGet package on MyGet. The feed is ready, but there are currently no artifacts pushed yet.

Providing the library as a NuGet package makes it easier for other projects to include it. This way, including the source in your own project (e.g. with a git subtree or module) is not needed anymore. Of course, this will force the library to be stable before it's pushed as a package on the feed. Deploying should be done automatically when pushing a new tag.
